### PR TITLE
fix: Update pnpm command in terminal window

### DIFF
--- a/packages/theme/organisms/home/terminal/HomeTabTerminalPnpm.vue
+++ b/packages/theme/organisms/home/terminal/HomeTabTerminalPnpm.vue
@@ -2,9 +2,10 @@
   <pre
       class="shiki shiki-themes github-light github-dark vp-code"
       tabindex="0"
-  ><code><span class="line"><span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0;">pnpx</span><span
-      style="--shiki-light:#005CC5;--shiki-dark:#79B8FF;"> -p</span><span
-      style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"> @tsed/cli</span><span
+  ><code><span class="line"><span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0;">pnpm</span><span
+      style="--shiki-light:#005CC5;--shiki-dark:#79B8FF;"> --package=</span><span
+      style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;">@tsed/cli</span><span
+      style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"> dlx</span><span
       style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"> tsed</span><span
       style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"> init</span><span
       style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"> .</span></span></code></pre>


### PR DESCRIPTION
I dunno how exactly the colors should be. So, here is a screenshot:
![image](https://github.com/user-attachments/assets/e62bb635-e778-4e28-b86e-4b9ceca22e8a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated terminal command example in the home tab to use `pnpm dlx` with updated flag syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->