### PR TITLE
test: Use regex instead of fixed number

### DIFF
--- a/packages/theme/organisms/warehouse/Warehouse.stories.ts
+++ b/packages/theme/organisms/warehouse/Warehouse.stories.ts
@@ -33,7 +33,7 @@ export const Default: Story = {
 
     const clearableFilter = screen.getByTestId("ClearableFilter");
 
-    await expect(within(clearableFilter).getByText(/plugins/)).toHaveTextContent("125 plugins found");
+    await expect(within(clearableFilter).getByText(/plugins/)).toHaveTextContent(/1\d{2} plugins found/);
 
     await expect(screen.getByText("@tsed/logger")).toBeInTheDocument();
     await expect(screen.getByText("@tsed/exceptions")).toBeInTheDocument();
@@ -62,6 +62,6 @@ export const Default: Story = {
 
     await userEvent.click(clearFilter, {delay: 500});
 
-    await expect(within(clearableFilter).getByText(/plugins/)).toHaveTextContent("125 plugins found");
+    await expect(within(clearableFilter).getByText(/plugins/)).toHaveTextContent(/1\d{2} plugins found/);
   }
 };


### PR DESCRIPTION
Had a notification about failing ci.
https://github.com/tsedio/tsed-vitepress-theme/actions/runs/12836072302

As this number changed from 126 to 125 and now to 122, would it be reasonable to just use a regex matching any "1xx" number now?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test assertions in the `Warehouse` component stories to use more flexible text matching for plugin count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->