### PR TITLE
fix: replace tsed.io by tsed.dev

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,7 +7,7 @@ export default defineConfig({
   lastUpdated: true,
 
   sitemap: {
-    hostname: "https://tsed.io"
+    hostname: "https://tsed.dev"
   },
 
   head: [
@@ -34,7 +34,7 @@ export default defineConfig({
     apiRedirectUrl: "",
     repo: "tsedio/tsed",
     team,
-    githubProxyUrl: "https://api.tsed.io/rest/github/tsedio/tsed",
+    githubProxyUrl: "https://api.tsed.dev/rest/github/tsedio/tsed",
     editLink: {
       pattern: "https://github.com/tsedio/tsed-vitepress-theme/edit/main/docs/:path"
     },
@@ -530,7 +530,7 @@ export default defineConfig({
     },
     socialLinks: [
       {icon: "github", link: "https://github.com/tsedio/tsed"},
-      {icon: "slack", link: "https://slack.tsed.io"},
+      {icon: "slack", link: "https://slack.tsed.dev"},
       {icon: "twitter", link: "https://x.com/TsED_io"}
       // { icon: '', link: 'https://stackoverflow.com/search?q=tsed' },
     ],

--- a/docs/docs/logger.md
+++ b/docs/docs/logger.md
@@ -1,6 +1,6 @@
 # Logger
 
-Ts.ED has its own logger available through [`@tsed/logger`](https://logger.tsed.io) package.
+Ts.ED has its own logger available through [`@tsed/logger`](https://logger.tsed.dev) package.
 
 ## Installation
 
@@ -30,8 +30,8 @@ Ts.ED logger supports many features, and is optimized to be used in production:
 
 - @@ContextLogger@@, in **production** mode, caches all request logs until the response is sent to your consumer.
   See [request logger](/docs/logger.html#request-logger) section bellow.
-- [Layouts](https://logger.tsed.io/layouts) support,
-- [Appenders](https://logger.tsed.io/appenders) support;
+- [Layouts](https://logger.tsed.dev/layouts) support,
+- [Appenders](https://logger.tsed.dev/appenders) support;
 
 ## Configuration
 
@@ -47,7 +47,7 @@ Logger can be configured through the @@Configuration@@ decorator:
 | `logger.reqIdBuilder`         | A function called for each incoming request to create a request id.                                                                                                                |
 | `logger.jsonIndentation`      | The number of space characters to use as white space in JSON output. Default is 2 (0 in production).                                                                               |
 | `logger.disableRoutesSummary` | Disable routes table displayed in the logger.                                                                                                                                      |
-| `logger.format`               | Specify log format. Example: `%[%d{[yyyy-MM-dd hh:mm:ss,SSS}] %p%] %m`. See [@tsed/logger configuration](https://logger.tsed.io).                                                  |
+| `logger.format`               | Specify log format. Example: `%[%d{[yyyy-MM-dd hh:mm:ss,SSS}] %p%] %m`. See [@tsed/logger configuration](https://logger.tsed.dev).                                                  |
 | `logger.ignoreUrlPatterns`    | (`String` or `RegExp`) List of patterns to ignore logged request according to the `request.url`.                                                                                   |
 
 </div>
@@ -60,46 +60,46 @@ It's recommended to disable logRequest in production. Logger has a cost on the p
 
 ### Layouts
 
-You can configure a [layout](https://logger.tsed.io/layouts) to format the log output. The following layouts are available:
+You can configure a [layout](https://logger.tsed.dev/layouts) to format the log output. The following layouts are available:
 
 | Name                                                                       | Description                                                                                                                        |
 | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| [Basic layout](https://logger.tsed.io/layouts/basic.html)                  | Basic layout will output the timestamp, level, category, followed by the formatted log event data.                                 |
-| [Colored layout](https://logger.tsed.io/layouts/colored.html)              | This layout is the same as basic, except that the timestamp, level and category will be colored according to the log event's level |
-| [Dummy layout](https://logger.tsed.io/layouts/dummy.html)                  | This layout only outputs the first value in the log event's data.                                                                  |
-| [Message layout](https://logger.tsed.io/layouts/message-pass-through.html) | Use a simple message format to display log                                                                                         |
-| [Json layout](https://logger.tsed.io/layouts/json.html)                    | Display log to JSON format                                                                                                         |
-| [Pattern layout](https://logger.tsed.io/layouts/pattern.html)              | Use custom pattern to format log                                                                                                   |
-| [Custom layout](https://logger.tsed.io/layouts/custom.html)                | logging to stdout or stderr with a custom layout.                                                                                  |
+| [Basic layout](https://logger.tsed.dev/layouts/basic.html)                  | Basic layout will output the timestamp, level, category, followed by the formatted log event data.                                 |
+| [Colored layout](https://logger.tsed.dev/layouts/colored.html)              | This layout is the same as basic, except that the timestamp, level and category will be colored according to the log event's level |
+| [Dummy layout](https://logger.tsed.dev/layouts/dummy.html)                  | This layout only outputs the first value in the log event's data.                                                                  |
+| [Message layout](https://logger.tsed.dev/layouts/message-pass-through.html) | Use a simple message format to display log                                                                                         |
+| [Json layout](https://logger.tsed.dev/layouts/json.html)                    | Display log to JSON format                                                                                                         |
+| [Pattern layout](https://logger.tsed.dev/layouts/pattern.html)              | Use custom pattern to format log                                                                                                   |
+| [Custom layout](https://logger.tsed.dev/layouts/custom.html)                | logging to stdout or stderr with a custom layout.                                                                                  |
 
 ### Appenders
 
-You can configure an [appender](https://logger.tsed.io/appenders) to send log events to a destination.
+You can configure an [appender](https://logger.tsed.dev/appenders) to send log events to a destination.
 The following appenders are available:
 
 | Name                                                                 | Description                                                                 |
 | -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| [Connect](https://logger.tsed.io/appenders/connect.html)             | allows connecting Ts.ED logger with another logger.                          |
-| [Console](https://logger.tsed.io/appenders/console.html)             | log to the console.                                                         |
-| [File](https://logger.tsed.io/appenders/file.html)                   | log to a file.                                                              |
-| [File date](https://logger.tsed.io/appenders/file-date.html)         | log to a file with configurable log rolling based on file size or date.     |
-| [Stdout](https://logger.tsed.io/appenders/stdout.html)               | log to stdout.                                                              |
-| [Stderr](https://logger.tsed.io/appenders/stderr.html)               | log to stderr.                                                              |
-| [Insight](https://logger.tsed.io/appenders/insight.html)             | log to [Insight](https://insight.io/).                                      |
-| [LogEntries](https://logger.tsed.io/appenders/logentries.html)       | log to [LogEntries](https://logentries.com/).                               |
-| [LogStash HTTP](https://logger.tsed.io/appenders/logstash-http.html) | log to [LogStash](https://www.elastic.co/logstash).                         |
-| [LogStash UDP](https://logger.tsed.io/appenders/logstash-udp.html)   | log to [LogStash](https://www.elastic.co/logstash).                         |
-| [Loggly](https://logger.tsed.io/appenders/loggly.html)               | log to [Loggly](https://www.loggly.com/).                                   |
-| [RabbitMQ](https://logger.tsed.io/appenders/rabbitmq.html)           | log to [RabbitMQ](https://www.rabbitmq.com/).                               |
-| [Seq](https://tsed.io/tutorials/seq.html)                            | log to [Seq](https://datalust.co/seq).                                      |
-| [Slack](https://logger.tsed.io/appenders/slack.html)                 | log to [Slack](https://slack.com/).                                         |
-| [Smtp](https://logger.tsed.io/appenders/smtp.html)                   | log to [SMTP](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol). |
+| [Connect](https://logger.tsed.dev/appenders/connect.html)             | allows connecting Ts.ED logger with another logger.                          |
+| [Console](https://logger.tsed.dev/appenders/console.html)             | log to the console.                                                         |
+| [File](https://logger.tsed.dev/appenders/file.html)                   | log to a file.                                                              |
+| [File date](https://logger.tsed.dev/appenders/file-date.html)         | log to a file with configurable log rolling based on file size or date.     |
+| [Stdout](https://logger.tsed.dev/appenders/stdout.html)               | log to stdout.                                                              |
+| [Stderr](https://logger.tsed.dev/appenders/stderr.html)               | log to stderr.                                                              |
+| [Insight](https://logger.tsed.dev/appenders/insight.html)             | log to [Insight](https://insight.io/).                                      |
+| [LogEntries](https://logger.tsed.dev/appenders/logentries.html)       | log to [LogEntries](https://logentries.com/).                               |
+| [LogStash HTTP](https://logger.tsed.dev/appenders/logstash-http.html) | log to [LogStash](https://www.elastic.co/logstash).                         |
+| [LogStash UDP](https://logger.tsed.dev/appenders/logstash-udp.html)   | log to [LogStash](https://www.elastic.co/logstash).                         |
+| [Loggly](https://logger.tsed.dev/appenders/loggly.html)               | log to [Loggly](https://www.loggly.com/).                                   |
+| [RabbitMQ](https://logger.tsed.dev/appenders/rabbitmq.html)           | log to [RabbitMQ](https://www.rabbitmq.com/).                               |
+| [Seq](https://tsed.dev/tutorials/seq.html)                            | log to [Seq](https://datalust.co/seq).                                      |
+| [Slack](https://logger.tsed.dev/appenders/slack.html)                 | log to [Slack](https://slack.com/).                                         |
+| [Smtp](https://logger.tsed.dev/appenders/smtp.html)                   | log to [SMTP](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol). |
 
 ::: tip
 You can create your own layout/appender:
 
-- [Customize appender (chanel)](https://logger.tsed.io/appenders/custom.html),
-- [Customize layout](https://logger.tsed.io/layouts/custom.html)
+- [Customize appender (chanel)](https://logger.tsed.dev/appenders/custom.html),
+- [Customize layout](https://logger.tsed.dev/layouts/custom.html)
 
 :::
 

--- a/docs/docs/model.md
+++ b/docs/docs/model.md
@@ -769,7 +769,7 @@ const result = deserialize<User>(
     id: "id", // will be ignored because creation doesn't include `id` field
     firstName: "firstName",
     lastName: "lastName",
-    email: "email@tsed.io",
+    email: "email@tsed.dev",
     password: "password"
   },
   {type: User, groups: ["creation"]}
@@ -786,7 +786,7 @@ const result = deserialize<User>(
     id: "id",
     firstName: "firstName",
     lastName: "lastName",
-    email: "email@tsed.io",
+    email: "email@tsed.dev",
     password: "password",
     roles: ["admin"]
   },
@@ -804,7 +804,7 @@ const result = deserialize<User>(
     id: "id",
     firstName: "firstName",
     lastName: "lastName",
-    email: "email@tsed.io",
+    email: "email@tsed.dev",
     password: "password",
     roles: ["admin"]
   },

--- a/docs/team.json
+++ b/docs/team.json
@@ -5,7 +5,7 @@
     "src": "https://avatars3.githubusercontent.com/u/1763311?v=4",
     "github": "Romakita",
     "twitter": "RomainLenzotti",
-    "website": "https://tsed.io",
+    "website": "https://tsed.dev",
     "country": "France",
     "city": "Paris",
     "role": "Framework Author"

--- a/docs/tutorials/graphql-apollo.md
+++ b/docs/tutorials/graphql-apollo.md
@@ -135,7 +135,7 @@ export class GraphQLWSModule {
 ```
 
 ::: tip Note
-Ts.ED provide a `@tsed/graphql-ws` package to support the `subscription` feature of GraphQL. See [here](https://tsed.io/api/graphql-ws.html) for more details.
+Ts.ED provide a `@tsed/graphql-ws` package to support the `subscription` feature of GraphQL. See [here](https://tsed.dev/api/graphql-ws.html) for more details.
 :::
 
 ## Get Server instance

--- a/docs/tutorials/graphql-ws.md
+++ b/docs/tutorials/graphql-ws.md
@@ -150,7 +150,7 @@ export class GraphQLWSModule {
 ```
 
 ::: tip Note
-Ts.ED provide a `@tsed/graphql-ws` package to support the `subscription` feature of GraphQL. See [here](https://tsed.io/api/graphql-ws.html) for more details.
+Ts.ED provide a `@tsed/graphql-ws` package to support the `subscription` feature of GraphQL. See [here](https://tsed.dev/api/graphql-ws.html) for more details.
 :::
 
 ## Nexus

--- a/docs/tutorials/snippets/graphql/graphql-ws.md
+++ b/docs/tutorials/snippets/graphql/graphql-ws.md
@@ -164,7 +164,7 @@ export class GraphQLWSModule {
 ```
 
 ::: tip Note
-Ts.ED provide a `@tsed/graphql-ws` package to support the `subscription` feature of GraphQL. See [here](https://tsed.io/api/graphql-ws.html) for more details.
+Ts.ED provide a `@tsed/graphql-ws` package to support the `subscription` feature of GraphQL. See [here](https://tsed.dev/api/graphql-ws.html) for more details.
 :::
 
 ## Nexus

--- a/packages/specs/json-mapper/readme.md
+++ b/packages/specs/json-mapper/readme.md
@@ -1,5 +1,5 @@
 <p style="text-align: center" align="center">
- <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+ <a href="https://tsed.dev" target="_blank"><img src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </p>
 
 <div align="center">
@@ -16,17 +16,17 @@
 </div>
 
 <div align="center">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/getting-started/">Getting started</a>
+  <a href="https://tsed.dev/getting-started/">Getting started</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://api.tsed.dev/rest/slack/tsedio/tsed">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>
 
 <hr />
-A package of Ts.ED framework. See website: https://tsed.io/
+A package of Ts.ED framework. See website: https://tsed.dev/
 
 The `@tsed/json-mapper` package is responsible to map a plain object to a model and a model to a plain object.
 
@@ -38,7 +38,7 @@ to a plain javascript object to your consumer.
 
 ## Documentation
 
-Documentation is available on [v6.tsed.io/docs/converters.html](https://v6.tsed.io/docs/converters.html)
+Documentation is available on [v6.tsed.dev/docs/converters.html](https://v6.tsed.dev/docs/converters.html)
 
 ## Installation
 
@@ -50,7 +50,7 @@ npm install --save @tsed/schema @tsed/json-mapper
 
 ## Contributors
 
-Please read [contributing guidelines here](https://tsed.io/contributing.html)
+Please read [contributing guidelines here](https://tsed.dev/contributing.html)
 
 <a href="https://github.com/tsedio/tsed/graphs/contributors"><img src="https://opencollective.com/tsed/contributors.svg?width=890" /></a>
 

--- a/packages/theme/composables/api/useApiContent.spec.ts
+++ b/packages/theme/composables/api/useApiContent.spec.ts
@@ -11,8 +11,8 @@ describe("useApiContent", () => {
       json: vi.fn().mockReturnValue({
         data: {
           value: {
-            apiRedirectUrl: "https://api-docs.tsed.io",
-            apiUrl: "https://tsed.io/api.json"
+            apiRedirectUrl: "https://api-docs.tsed.dev",
+            apiUrl: "https://tsed.dev/api.json"
           }
         }
       })
@@ -24,12 +24,12 @@ describe("useApiContent", () => {
     expect(result).toEqual({
       data: {
         value: {
-          apiRedirectUrl: "https://api-docs.tsed.io",
-          apiUrl: "https://tsed.io/api.json"
+          apiRedirectUrl: "https://api-docs.tsed.dev",
+          apiUrl: "https://tsed.dev/api.json"
         }
       }
     });
-    expect(useFetch).toHaveBeenCalledWith("https://tsed.io/api.json",{
+    expect(useFetch).toHaveBeenCalledWith("https://tsed.dev/api.json",{
       afterFetch: expect.any(Function)
     });
   });

--- a/packages/theme/composables/api/useApiLink.spec.ts
+++ b/packages/theme/composables/api/useApiLink.spec.ts
@@ -4,8 +4,8 @@ vi.mock("../config/useThemeConfig.js", () => {
   return {
     useThemeConfig: () => ({
       value: {
-        apiRedirectUrl: "https://api-docs.tsed.io",
-        apiUrl: "https://tsed.io/api.json"
+        apiRedirectUrl: "https://api-docs.tsed.dev",
+        apiUrl: "https://tsed.dev/api.json"
       }
     })
   };
@@ -15,7 +15,7 @@ describe("useApiLink", () => {
   it("should build a valid url", () => {
     const result = useApiLink();
 
-    expect(result({path: "/hello"} as any)).toEqual("https://api-docs.tsed.io/hello.html");
+    expect(result({path: "/hello"} as any)).toEqual("https://api-docs.tsed.dev/hello.html");
   });
   it("should return empty string if path is missing", () => {
     const result = useApiLink();

--- a/packages/theme/composables/config/__mocks__/useThemeConfig.ts
+++ b/packages/theme/composables/config/__mocks__/useThemeConfig.ts
@@ -1,9 +1,9 @@
 export function useThemeConfig() {
   const ref: { apiUrl: string; apiRedirectUrl: string; repo: string; githubProxyUrl: string; value: any } = {
-    apiUrl: "https://tsed.io/api.json",
-    apiRedirectUrl: "https://api-docs.tsed.io",
+    apiUrl: "https://tsed.dev/api.json",
+    apiRedirectUrl: "https://api-docs.tsed.dev",
     repo: "tsedio/tsed",
-    githubProxyUrl: "https://api.tsed.io/rest/github/tsedio/tsed",
+    githubProxyUrl: "https://api.tsed.dev/rest/github/tsedio/tsed",
     value: undefined
   };
 

--- a/packages/theme/composables/config/useFrontMatter.spec.ts
+++ b/packages/theme/composables/config/useFrontMatter.spec.ts
@@ -7,57 +7,57 @@ describe("useFrontMatter", () => {
         {
           title: "Kit basic",
           href: "https://github.com/tsedio/tsed-getting-started",
-          src: "https://tsed.io/tsed.png"
+          src: "https://tsed.dev/tsed.png"
         },
         {
           title: "Kit production-ready template",
           href: "https://github.com/borjapazr/express-typescript-skeleton",
-          src: "https://tsed.io/tsed.png"
+          src: "https://tsed.dev/tsed.png"
         },
         {
           title: "Kit React",
           href: "https://github.com/tsedio/tsed-example-react",
-          src: "https://tsed.io/react.png"
+          src: "https://tsed.dev/react.png"
         },
         {
           title: "Kit Vue.js",
           href: "https://github.com/tsedio/tsed-example-vuejs",
-          src: "https://tsed.io/vuejs.png"
+          src: "https://tsed.dev/vuejs.png"
         },
         {
           title: "Kit Prisma",
           href: "https://github.com/tsedio/tsed-example-prisma",
-          src: "https://tsed.io/prisma-2.png"
+          src: "https://tsed.dev/prisma-2.png"
         },
         {
           title: "Kit TypeORM",
           href: "https://github.com/tsedio/tsed-example-typeorm",
-          src: "https://tsed.io/typeorm.png"
+          src: "https://tsed.dev/typeorm.png"
         },
         {
           title: "Kit Mongoose",
           href: "https://github.com/tsedio/tsed-example-mongoose",
-          src: "https://tsed.io/mongoose.png"
+          src: "https://tsed.dev/mongoose.png"
         },
         {
           title: "Kit Socket.io",
           href: "https://github.com/tsedio/tsed-example-socketio",
-          src: "https://tsed.io/socketio.png"
+          src: "https://tsed.dev/socketio.png"
         },
         {
           title: "Kit Passport.js",
           href: "https://github.com/tsedio/tsed-example-passportjs",
-          src: "https://tsed.io/passportjs.png"
+          src: "https://tsed.dev/passportjs.png"
         },
         {
           title: "Kit AWS",
           href: "https://github.com/tsedio/tsed-example-aws",
-          src: "https://tsed.io/aws.png"
+          src: "https://tsed.dev/aws.png"
         },
         {
           title: "Kit Azure AD",
           href: "https://github.com/tsedio/tsed-example-passport-azure-ad",
-          src: "https://tsed.io/azure.png"
+          src: "https://tsed.dev/azure.png"
         }
       ],
       value: undefined

--- a/packages/theme/composables/config/useThemeConfig.spec.ts
+++ b/packages/theme/composables/config/useThemeConfig.spec.ts
@@ -3,9 +3,9 @@ import {useThemeConfig} from "./useThemeConfig";
 describe("useThemeConfig", () => {
   it("should return the correct api config", () => {
     const ref: any = {
-      apiRedirectUrl: "https://api-docs.tsed.io",
-      apiUrl: "https://tsed.io/api.json",
-      "githubProxyUrl": "https://api.tsed.io/rest/github/tsedio/tsed",
+      apiRedirectUrl: "https://api-docs.tsed.dev",
+      apiUrl: "https://tsed.dev/api.json",
+      "githubProxyUrl": "https://api.tsed.dev/rest/github/tsedio/tsed",
       "repo": "tsedio/tsed",
       value: undefined
     };

--- a/packages/theme/molecules/api-anchor/ApiAnchor.spec.ts
+++ b/packages/theme/molecules/api-anchor/ApiAnchor.spec.ts
@@ -17,7 +17,7 @@ describe("<ApiAnchor>", () => {
 
     expect(screen.getByText("Symbol name")).toBeTruthy();
     expect(screen.getByText("Symbol name")).not.toHaveClass();
-    expect(screen.getByRole("link")).toHaveAttribute("href", "https://api-docs.tsed.io/path.html");
+    expect(screen.getByRole("link")).toHaveAttribute("href", "https://api-docs.tsed.dev/path.html");
     expect(screen.getByRole("link")).toHaveAttribute("class", "reset-link -bubble");
     expect(screen.getByRole("link")).toHaveAttribute("title", "Symbol name");
   });
@@ -37,7 +37,7 @@ describe("<ApiAnchor>", () => {
 
     expect(screen.getByText("Symbol name")).toBeTruthy();
     expect(screen.getByText("Symbol name")).toHaveClass("line-through");
-    expect(screen.getByRole("link")).toHaveAttribute("href", "https://api-docs.tsed.io/path.html");
+    expect(screen.getByRole("link")).toHaveAttribute("href", "https://api-docs.tsed.dev/path.html");
     expect(screen.getByRole("link")).toHaveClass("reset-link -bubble");
   });
 });

--- a/packages/theme/molecules/button-badge/__mock__/frameworks.json
+++ b/packages/theme/molecules/button-badge/__mock__/frameworks.json
@@ -2,27 +2,27 @@
   {
     "title": "TypeScript",
     "href": "https://www.typescriptlang.org/",
-    "src": "https://tsed.io/typescript.png"
+    "src": "https://tsed.dev/typescript.png"
   },
   {
     "title": "Express.js",
     "href": "https://expressjs.com/",
-    "src": "https://tsed.io/expressjs.svg"
+    "src": "https://tsed.dev/expressjs.svg"
   },
   {
     "title": "Koa.js",
     "href": "https://koajs.com/",
-    "src": "https://tsed.io/koa.svg"
+    "src": "https://tsed.dev/koa.svg"
   },
   {
     "title": "Jest",
     "href": "https://jestjs.io/",
-    "src": "https://tsed.io/jest.svg"
+    "src": "https://tsed.dev/jest.svg"
   },
   {
     "title": "Mocha",
     "href": "https://mochajs.org/",
-    "src": "https://tsed.io/mochajs.svg"
+    "src": "https://tsed.dev/mochajs.svg"
   },
   {
     "title": "AJV",
@@ -32,31 +32,31 @@
   {
     "title": "Swagger",
     "href": "/tutorials/swagger.html",
-    "src": "https://tsed.io/swagger.svg"
+    "src": "https://tsed.dev/swagger.svg"
   },
   {
     "title": "Passport",
     "href": "/tutorials/passport.html",
-    "src": "https://tsed.io/passportjs.png"
+    "src": "https://tsed.dev/passportjs.png"
   },
   {
     "title": "Mongoose",
     "href": "/tutorials/mongoose.html",
-    "src": "https://tsed.io/mongoose.png"
+    "src": "https://tsed.dev/mongoose.png"
   },
   {
     "title": "TypeORM",
     "href": "/tutorials/typeorm.html",
-    "src": "https://tsed.io/typeorm.png"
+    "src": "https://tsed.dev/typeorm.png"
   },
   {
     "title": "TypeGraphQL",
     "href": "/tutorials/graphql.html",
-    "src": "https://tsed.io/typegraphql.png"
+    "src": "https://tsed.dev/typegraphql.png"
   },
   {
     "title": "Socket.io",
     "href": "/tutorials/socketio.html",
-    "src": "https://tsed.io/socketio.svg"
+    "src": "https://tsed.dev/socketio.svg"
   }
 ]

--- a/packages/theme/molecules/card-package/CardPackage.spec.ts
+++ b/packages/theme/molecules/card-package/CardPackage.spec.ts
@@ -10,7 +10,7 @@ describe("<CardPackage />", () => {
           description: "A TypeScript Framework on top of Express",
           repository: "https://github.com/tsedio/tsed",
           npm: "https://www.npmjs.com/package/%40tsed%2Fplatform-express",
-          icon: "https://tsed.io/expressjs.svg",
+          icon: "https://tsed.dev/expressjs.svg",
           homepage: "https://github.com/tsedio/tsed/tree/production/packages/platform/platform-express",
           maintainers: [
             {
@@ -46,7 +46,7 @@ describe("<CardPackage />", () => {
           description: "A TypeScript Framework on top of Express",
           repository: "https://github.com/tsedio/tsed",
           npm: "https://www.npmjs.com/package/%40tsed%2Fplatform-express",
-          icon: "https://tsed.io/expressjs.svg",
+          icon: "https://tsed.dev/expressjs.svg",
           homepage: "https://github.com/tsedio/tsed/tree/production/packages/platform/platform-express",
           maintainers: [
             {

--- a/packages/theme/molecules/card-package/CardPackage.stories.ts
+++ b/packages/theme/molecules/card-package/CardPackage.stories.ts
@@ -22,7 +22,7 @@ export const Official: Story = {
     description: "A TypeScript Framework on top of Express",
     repository: "https://github.com/tsedio/tsed",
     npm: "https://www.npmjs.com/package/%40tsed%2Fplatform-express",
-    icon: "https://tsed.io/expressjs.svg",
+    icon: "https://tsed.dev/expressjs.svg",
     homepage: "https://github.com/tsedio/tsed/tree/production/packages/platform/platform-express",
     maintainers: [
       {
@@ -58,7 +58,7 @@ export const Premium: Story = {
     description: "A TypeScript Framework on top of Express",
     repository: "https://github.com/tsedio/tsed",
     npm: "https://www.npmjs.com/package/%40tsed%2Fplatform-express",
-    icon: "https://tsed.io/expressjs.svg",
+    icon: "https://tsed.dev/expressjs.svg",
     homepage: "https://github.com/tsedio/tsed/tree/production/packages/platform/platform-express",
     maintainers: [
       {
@@ -94,7 +94,7 @@ export const Community: Story = {
     description: "A TypeScript Framework on top of Express",
     repository: "https://github.com/tsedio/tsed",
     npm: "https://www.npmjs.com/package/%40tsed%2Fplatform-express",
-    icon: "https://tsed.io/expressjs.svg",
+    icon: "https://tsed.dev/expressjs.svg",
     homepage: "https://github.com/tsedio/tsed/tree/production/packages/platform/platform-express",
     maintainers: [
       {

--- a/packages/theme/molecules/card-package/__mock__/plugins.json
+++ b/packages/theme/molecules/card-package/__mock__/plugins.json
@@ -5,7 +5,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fexceptions",
-    "icon": "https://api.tsed.io/statics/warehouse/tsed.svg",
+    "icon": "https://api.tsed.dev/statics/warehouse/tsed.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/specs/exceptions",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -27,7 +27,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fopenspec",
-    "icon": "https://tsed.io/swagger.svg",
+    "icon": "https://tsed.dev/swagger.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/specs/openspec",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -51,7 +51,7 @@
     "version": "6.7.5",
     "repository": "https://github.com/tsedio/logger",
     "npm": "https://www.npmjs.com/package/%40tsed%2Flogger",
-    "icon": "https://api.tsed.io/statics/warehouse/tsed.svg",
+    "icon": "https://api.tsed.dev/statics/warehouse/tsed.svg",
     "homepage": "https://github.com/tsedio/logger/tree/production/packages/logger",
     "bugs": "https://github.com/tsedio/logger/issues",
     "maintainers": [
@@ -73,7 +73,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fplatform-express",
-    "icon": "https://tsed.io/expressjs.svg",
+    "icon": "https://tsed.dev/expressjs.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/platform/platform-express",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -254,7 +254,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fswagger",
-    "icon": "https://tsed.io/swagger.svg",
+    "icon": "https://tsed.dev/swagger.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/specs/swagger",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -278,8 +278,8 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fengines",
-    "icon": "https://api.tsed.io/statics/warehouse/tsed.svg",
-    "homepage": "https://tsed.io/docs/templating.html#configuration",
+    "icon": "https://api.tsed.dev/statics/warehouse/tsed.svg",
+    "homepage": "https://tsed.dev/docs/templating.html#configuration",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
       {
@@ -412,7 +412,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fsocketio",
-    "icon": "https://tsed.io/socketio.svg",
+    "icon": "https://tsed.dev/socketio.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/third-parties/socketio",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -458,7 +458,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fpassport",
-    "icon": "https://tsed.io/passportjs.png",
+    "icon": "https://tsed.dev/passportjs.png",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/security/passport",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -482,7 +482,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Ftypeorm",
-    "icon": "https://tsed.io/typeorm.png",
+    "icon": "https://tsed.dev/typeorm.png",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/orm/typeorm",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -506,7 +506,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fmongoose",
-    "icon": "https://tsed.io/mongoose.png",
+    "icon": "https://tsed.dev/mongoose.png",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/orm/mongoose",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -530,7 +530,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Ftesting-mongoose",
-    "icon": "https://tsed.io/mongoose.png",
+    "icon": "https://tsed.dev/mongoose.png",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/orm/testing-mongoose",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -602,7 +602,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fadapters",
-    "icon": "https://api.tsed.io/statics/warehouse/tsed.svg",
+    "icon": "https://api.tsed.dev/statics/warehouse/tsed.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/orm/adapters",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -648,7 +648,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fplatform-koa",
-    "icon": "https://tsed.io/koa.svg",
+    "icon": "https://tsed.dev/koa.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/platform/platform-koa",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -672,8 +672,8 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fprisma",
-    "icon": "https://tsed.io/prisma-2.svg",
-    "homepage": "https://tsed.io/tutorials/prisma.html",
+    "icon": "https://tsed.dev/prisma-2.svg",
+    "homepage": "https://tsed.dev/tutorials/prisma.html",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
       {
@@ -724,8 +724,8 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fapollo",
-    "icon": "https://tsed.io/apollo-graphql-1.svg",
-    "homepage": "https://tsed.io/tutorials/graphql.html",
+    "icon": "https://tsed.dev/apollo-graphql-1.svg",
+    "homepage": "https://tsed.dev/tutorials/graphql.html",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
       {
@@ -772,7 +772,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fstripe",
-    "icon": "https://tsed.io/stripe.svg",
+    "icon": "https://tsed.dev/stripe.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/third-parties/stripe",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -797,8 +797,8 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Ftypegraphql",
-    "icon": "https://tsed.io/typegraphql.png",
-    "homepage": "https://tsed.io/tutorials/graphql.html",
+    "icon": "https://tsed.dev/typegraphql.png",
+    "homepage": "https://tsed.dev/tutorials/graphql.html",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
       {
@@ -889,7 +889,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fsocketio-testing",
-    "icon": "https://tsed.io/socketio.svg",
+    "icon": "https://tsed.dev/socketio.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/third-parties/socketio-testing",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -913,8 +913,8 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fagenda",
-    "icon": "https://tsed.io/agenda.svg",
-    "homepage": "https://tsed.io/tutorials/agenda.html",
+    "icon": "https://tsed.dev/agenda.svg",
+    "homepage": "https://tsed.dev/tutorials/agenda.html",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
       {
@@ -1056,7 +1056,7 @@
     "version": "7.82.1",
     "repository": "https://github.com/tsedio/tsed",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fevent-emitter",
-    "icon": "https://api.tsed.io/statics/warehouse/tsed.svg",
+    "icon": "https://api.tsed.dev/statics/warehouse/tsed.svg",
     "homepage": "https://github.com/tsedio/tsed/tree/production/packages/third-parties/event-emitter",
     "bugs": "https://github.com/tsedio/tsed/issues",
     "maintainers": [
@@ -1110,7 +1110,7 @@
     "version": "5.2.7",
     "repository": "https://github.com/tsedio/tsed-cli",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fcli-plugin-eslint",
-    "icon": "https://cli.tsed.io/eslint.svg",
+    "icon": "https://cli.tsed.dev/eslint.svg",
     "homepage": "https://github.com/tsedio/tsed-cli/tree/master/packages/cli-plugin-eslint",
     "bugs": "https://github.com/tsedio/tsed-cli/issues",
     "maintainers": [
@@ -1156,7 +1156,7 @@
     "version": "5.2.7",
     "repository": "https://github.com/tsedio/tsed-cli",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fcli-plugin-jest",
-    "icon": "https://tsed.io/jest.svg",
+    "icon": "https://tsed.dev/jest.svg",
     "homepage": "https://github.com/tsedio/tsed-cli/tree/master/packages/cli-plugin-jest",
     "bugs": "https://github.com/tsedio/tsed-cli/issues",
     "maintainers": [
@@ -1202,7 +1202,7 @@
     "version": "5.2.7",
     "repository": "https://github.com/tsedio/tsed-cli",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fcli",
-    "icon": "https://api.tsed.io/statics/warehouse/tsed.svg",
+    "icon": "https://api.tsed.dev/statics/warehouse/tsed.svg",
     "homepage": "https://github.com/tsedio/tsed-cli/tree/master/packages/cli",
     "bugs": "https://github.com/tsedio/tsed-cli/issues",
     "maintainers": [
@@ -1224,7 +1224,7 @@
     "version": "5.2.7",
     "repository": "https://github.com/tsedio/tsed-cli",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fcli-plugin-passport",
-    "icon": "https://tsed.io/passportjs.png",
+    "icon": "https://tsed.dev/passportjs.png",
     "homepage": "https://github.com/tsedio/tsed-cli/tree/master/packages/cli-plugin-passport",
     "bugs": "https://github.com/tsedio/tsed-cli/issues",
     "maintainers": [
@@ -1249,7 +1249,7 @@
     "version": "5.2.7",
     "repository": "https://github.com/tsedio/tsed-cli",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fcli-plugin-mongoose",
-    "icon": "https://tsed.io/mongoose.png",
+    "icon": "https://tsed.dev/mongoose.png",
     "homepage": "https://github.com/tsedio/tsed-cli/tree/master/packages/cli-plugin-mongoose",
     "bugs": "https://github.com/tsedio/tsed-cli/issues",
     "maintainers": [
@@ -1296,7 +1296,7 @@
     "version": "5.2.7",
     "repository": "https://github.com/tsedio/tsed-cli",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fcli-plugin-typeorm",
-    "icon": "https://tsed.io/typeorm.png",
+    "icon": "https://tsed.dev/typeorm.png",
     "homepage": "https://github.com/tsedio/tsed-cli/tree/master/packages/cli-plugin-typeorm",
     "bugs": "https://github.com/tsedio/tsed-cli/issues",
     "maintainers": [
@@ -1434,7 +1434,7 @@
     "version": "5.2.7",
     "repository": "https://github.com/tsedio/tsed-cli",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fcli-plugin-prisma",
-    "icon": "https://tsed.io/prisma-2.svg",
+    "icon": "https://tsed.dev/prisma-2.svg",
     "homepage": "https://github.com/tsedio/tsed-cli/tree/master/packages/cli-plugin-prisma",
     "bugs": "https://github.com/tsedio/tsed-cli/issues",
     "maintainers": [
@@ -1458,7 +1458,7 @@
     "version": "5.2.7",
     "repository": "https://github.com/tsedio/tsed-cli",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fcli-plugin-mocha",
-    "icon": "https://tsed.io/mochajs.svg",
+    "icon": "https://tsed.dev/mochajs.svg",
     "homepage": "https://github.com/tsedio/tsed-cli/tree/master/packages/cli-plugin-mocha",
     "bugs": "https://github.com/tsedio/tsed-cli/issues",
     "maintainers": [
@@ -1525,7 +1525,7 @@
     "version": "5.2.7",
     "repository": "https://github.com/tsedio/tsed-cli",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fcli-testing",
-    "icon": "https://api.tsed.io/statics/warehouse/tsed.svg",
+    "icon": "https://api.tsed.dev/statics/warehouse/tsed.svg",
     "homepage": "https://github.com/tsedio/tsed-cli/tree/master/packages/cli-testing",
     "bugs": "https://github.com/tsedio/tsed-cli/issues",
     "maintainers": [
@@ -1549,7 +1549,7 @@
     "version": "6.7.5",
     "repository": "https://github.com/tsedio/logger",
     "npm": "https://www.npmjs.com/package/%40tsed%2Flogger-logstash-http",
-    "icon": "https://tsed.io/elastic-logstash.svg",
+    "icon": "https://tsed.dev/elastic-logstash.svg",
     "homepage": "https://github.com/tsedio/logger/tree/production/packages/logstash-http",
     "bugs": "https://github.com/tsedio/logger/issues",
     "maintainers": [
@@ -1649,7 +1649,7 @@
     "version": "6.7.5",
     "repository": "https://github.com/tsedio/logger",
     "npm": "https://www.npmjs.com/package/%40tsed%2Flogger-loggly",
-    "icon": "https://tsed.io/loggly.svg",
+    "icon": "https://tsed.dev/loggly.svg",
     "homepage": "https://github.com/tsedio/logger/tree/production/packages/loggly",
     "bugs": "https://github.com/tsedio/logger/issues",
     "maintainers": [
@@ -1673,7 +1673,7 @@
     "version": "6.7.5",
     "repository": "https://github.com/tsedio/logger",
     "npm": "https://www.npmjs.com/package/%40tsed%2Flogger-insight",
-    "icon": "https://tsed.io/rapid7.svg",
+    "icon": "https://tsed.dev/rapid7.svg",
     "homepage": "https://github.com/tsedio/logger/tree/production/packages/insight",
     "bugs": "https://github.com/tsedio/logger/issues",
     "maintainers": [
@@ -1745,7 +1745,7 @@
     "version": "6.7.5",
     "repository": "https://github.com/tsedio/logger",
     "npm": "https://www.npmjs.com/package/%40tsed%2Flogger-rabbitmq",
-    "icon": "https://tsed.io/rabbitmq.svg",
+    "icon": "https://tsed.dev/rabbitmq.svg",
     "homepage": "https://github.com/tsedio/logger/tree/production/packages/rabbitmq",
     "bugs": "https://github.com/tsedio/logger/issues",
     "maintainers": [
@@ -1769,7 +1769,7 @@
     "version": "6.7.5",
     "repository": "https://github.com/tsedio/logger",
     "npm": "https://www.npmjs.com/package/%40tsed%2Flogger-logentries",
-    "icon": "https://tsed.io/logentries.svg",
+    "icon": "https://tsed.dev/logentries.svg",
     "homepage": "https://github.com/tsedio/logger/tree/production/packages/logentries",
     "bugs": "https://github.com/tsedio/logger/issues",
     "maintainers": [
@@ -1789,7 +1789,7 @@
   },
   {
     "name": "serverless-tsed-plugin",
-    "description": "This plugin integrates [Ts.ED](https://tsed.io/) with the Serverless Framework, allowing you to automatically generate Serverless functions from your Ts.ED controllers.",
+    "description": "This plugin integrates [Ts.ED](https://tsed.dev/) with the Serverless Framework, allowing you to automatically generate Serverless functions from your Ts.ED controllers.",
     "version": "0.2.0",
     "repository": "https://github.com/mecanizou-eco/serverless-tsed-plugin",
     "npm": "https://www.npmjs.com/package/serverless-tsed-plugin",
@@ -1837,7 +1837,7 @@
     "version": "6.7.5",
     "repository": "https://github.com/tsedio/logger",
     "npm": "https://www.npmjs.com/package/%40tsed%2Flogger-logstash-udp",
-    "icon": "https://tsed.io/elastic-logstash.svg",
+    "icon": "https://tsed.dev/elastic-logstash.svg",
     "homepage": "https://github.com/tsedio/logger/tree/production/packages/logstash-udp",
     "bugs": "https://github.com/tsedio/logger/issues",
     "maintainers": [
@@ -1861,7 +1861,7 @@
     "version": "6.7.5",
     "repository": "https://github.com/tsedio/logger",
     "npm": "https://www.npmjs.com/package/%40tsed%2Flogger-slack",
-    "icon": "https://tsed.io/slack.svg",
+    "icon": "https://tsed.dev/slack.svg",
     "homepage": "https://github.com/tsedio/logger/tree/production/packages/slack",
     "bugs": "https://github.com/tsedio/logger/issues",
     "maintainers": [
@@ -2038,7 +2038,7 @@
     "version": "1.24.1",
     "repository": "https://github.com/tsedio/tsed-monorepo-utils",
     "npm": "https://www.npmjs.com/package/%40tsed%2Fyarn-workspaces",
-    "icon": "https://api.tsed.io/statics/warehouse/tsed.svg",
+    "icon": "https://api.tsed.dev/statics/warehouse/tsed.svg",
     "homepage": "https://github.com/tsedio/tsed-monorepo-utils#readme",
     "maintainers": [
       {
@@ -2340,7 +2340,7 @@
   {
     "name": "@tsed/async-hook-context",
     "description": "Add Async Hook context support in Ts.ED",
-    "icon": "https://api.tsed.io/statics/warehouse/tsed.svg",
+    "icon": "https://api.tsed.dev/statics/warehouse/tsed.svg",
     "maintainers": [],
     "downloads": 0,
     "stars": 0,
@@ -2354,7 +2354,7 @@
   {
     "name": "@tsed/platform-aws",
     "description": "Module to support AWS function with Ts.ED",
-    "icon": "https://tsed.io/aws.png",
+    "icon": "https://tsed.dev/aws.png",
     "maintainers": [],
     "downloads": 0,
     "stars": 0,
@@ -2404,7 +2404,7 @@
   },
   {
     "name": "vuepress-theme-tsed",
-    "description": "Vuepress theme for tsed.io",
+    "description": "Vuepress theme for tsed.dev",
     "maintainers": [],
     "downloads": 0,
     "stars": 0,
@@ -2425,7 +2425,7 @@
   {
     "name": "@tsed/graphql",
     "description": "GraphQL package for Ts.ED framework, based on Apollo-server-express and Type-graphql",
-    "icon": "https://tsed.io/typegraphql.png",
+    "icon": "https://tsed.dev/typegraphql.png",
     "maintainers": [],
     "downloads": 0,
     "stars": 0,

--- a/packages/theme/readme.md
+++ b/packages/theme/readme.md
@@ -1,5 +1,5 @@
 <p style="text-align: center" align="center">
- <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+ <a href="https://tsed.dev" target="_blank"><img src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </p>
 
 <div align="center">
@@ -17,11 +17,11 @@
 </div>
 
 <div align="center">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/getting-started/">Getting started</a>
+  <a href="https://tsed.dev/getting-started/">Getting started</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://api.tsed.dev/rest/slack/tsedio/tsed">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 <p style="text-align: center" align="center">
- <a href="https://tsed.io" target="_blank"><img src="https://tsed.io/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
+ <a href="https://tsed.dev" target="_blank"><img src="https://tsed.dev/tsed-og.png" width="200" alt="Ts.ED logo"/></a>
 </p>
 
 <div align="center">
@@ -17,11 +17,11 @@
 </div>
 
 <div align="center">
-  <a href="https://tsed.io/">Website</a>
+  <a href="https://tsed.dev/">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://tsed.io/getting-started/">Getting started</a>
+  <a href="https://tsed.dev/getting-started/">Getting started</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://api.tsed.io/rest/slack/tsedio/tsed">Slack</a>
+  <a href="https://api.tsed.dev/rest/slack/tsedio/tsed">Slack</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://twitter.com/TsED_io">Twitter</a>
 </div>
@@ -32,7 +32,7 @@
 
 ## What it is
 
-This repository is the new website for Ts.ED. It replaces the old website [https://tsed.io](https://tsed.io) based on [VuePress 1.x](https://vuepress.vuejs.org/) by a new website based on [VitePress](https://vitepress.dev).
+This repository is the new website for Ts.ED. It replaces the old website [https://tsed.dev](https://tsed.dev) based on [VuePress 1.x](https://vuepress.vuejs.org/) by a new website based on [VitePress](https://vitepress.dev).
 
 ## Installation
 

--- a/test/vitepress.client.ts
+++ b/test/vitepress.client.ts
@@ -1,8 +1,8 @@
 export function useData() {
   const ref = {
-    apiUrl: "https://tsed.io/api.json",
-    apiRedirectUrl: "https://api-docs.tsed.io",
-    githubProxyUrl: "https://api.tsed.io/rest/github/tsedio/tsed",
+    apiUrl: "https://tsed.dev/api.json",
+    apiRedirectUrl: "https://api-docs.tsed.dev",
+    githubProxyUrl: "https://api.tsed.dev/rest/github/tsedio/tsed",
     repo: "tsedio/tsed",
     value: undefined
   };
@@ -14,57 +14,57 @@ export function useData() {
       {
         title: "Kit basic",
         href: "https://github.com/tsedio/tsed-getting-started",
-        src: "https://tsed.io/tsed.png"
+        src: "https://tsed.dev/tsed.png"
       },
       {
         title: "Kit production-ready template",
         href: "https://github.com/borjapazr/express-typescript-skeleton",
-        src: "https://tsed.io/tsed.png"
+        src: "https://tsed.dev/tsed.png"
       },
       {
         title: "Kit React",
         href: "https://github.com/tsedio/tsed-example-react",
-        src: "https://tsed.io/react.png"
+        src: "https://tsed.dev/react.png"
       },
       {
         title: "Kit Vue.js",
         href: "https://github.com/tsedio/tsed-example-vuejs",
-        src: "https://tsed.io/vuejs.png"
+        src: "https://tsed.dev/vuejs.png"
       },
       {
         title: "Kit Prisma",
         href: "https://github.com/tsedio/tsed-example-prisma",
-        src: "https://tsed.io/prisma-2.png"
+        src: "https://tsed.dev/prisma-2.png"
       },
       {
         title: "Kit TypeORM",
         href: "https://github.com/tsedio/tsed-example-typeorm",
-        src: "https://tsed.io/typeorm.png"
+        src: "https://tsed.dev/typeorm.png"
       },
       {
         title: "Kit Mongoose",
         href: "https://github.com/tsedio/tsed-example-mongoose",
-        src: "https://tsed.io/mongoose.png"
+        src: "https://tsed.dev/mongoose.png"
       },
       {
         title: "Kit Socket.io",
         href: "https://github.com/tsedio/tsed-example-socketio",
-        src: "https://tsed.io/socketio.png"
+        src: "https://tsed.dev/socketio.png"
       },
       {
         title: "Kit Passport.js",
         href: "https://github.com/tsedio/tsed-example-passportjs",
-        src: "https://tsed.io/passportjs.png"
+        src: "https://tsed.dev/passportjs.png"
       },
       {
         title: "Kit AWS",
         href: "https://github.com/tsedio/tsed-example-aws",
-        src: "https://tsed.io/aws.png"
+        src: "https://tsed.dev/aws.png"
       },
       {
         title: "Kit Azure AD",
         href: "https://github.com/tsedio/tsed-example-passport-azure-ad",
-        src: "https://tsed.io/azure.png"
+        src: "https://tsed.dev/azure.png"
       }
     ],
     value: undefined


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated all user-facing links, examples, and references in documentation and tutorials to the new tsed.dev domain.
- **Chores**
	- Aligned configuration settings and internal endpoints with the new domain, ensuring consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->